### PR TITLE
add pase_json config param

### DIFF
--- a/lib/fluent/plugin/out_flatten.rb
+++ b/lib/fluent/plugin/out_flatten.rb
@@ -7,8 +7,9 @@ module Fluent
 
     Fluent::Plugin.register_output('flatten', self)
 
-    config_param :key,       :string
-    config_param :inner_key, :string, :default => 'value'
+    config_param :key,        :string
+    config_param :inner_key,  :string, :default => 'value'
+    config_param :parse_json, :bool,   :default => true 
 
     def configure(conf)
       super
@@ -45,10 +46,14 @@ module Fluent
         hash = nil
 
         begin
-          # XXX work-around
-          # fluentd seems to escape json value excessively
-          json = record[key].gsub(/\\"/, '"')
-          hash = JSON.parse(json)
+          if parse_json
+            # XXX work-around
+            # fluentd seems to escape json value excessively
+            json = record[key].gsub(/\\"/, '"')
+            hash = JSON.parse(json)
+          else
+            hash = record[key]
+          end
         rescue JSON::ParserError
           return flattened
         end


### PR DESCRIPTION
既存のアプリログから統計データを算出するのにJSONのparseを実行しないバージョンが欲しかったので実装してみました。

I tried to implement because it wanted a version that does not run the parse JSON and to calculate the statistical data from the application log of existing.
