### PR TITLE
Add test-unit gem development dependency

### DIFF
--- a/fluent-plugin-flatten.gemspec
+++ b/fluent-plugin-flatten.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'test-unit', '~> 3.1.0'
   gem.add_runtime_dependency     'fluentd'
 end
 


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.

Enjoy fluentd plugin development with Ruby 2.2!