### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_flatten.rb
+++ b/lib/fluent/plugin/out_flatten.rb
@@ -12,9 +12,16 @@ module Fluent
       define_method("router") { Fluent::Engine }
     end
 
-    config_param :key,        :string
-    config_param :inner_key,  :string, :default => 'value'
-    config_param :parse_json, :bool,   :default => true 
+    config_param :key,        :string,
+                 :desc => <<-DESC
+The key is used to point a key whose value contains JSON-formatted string.
+DESC
+    config_param :inner_key,  :string, :default => 'value',
+                 :desc => <<-DESC
+This plugin sets `value` for this option as a default if it's not set.
+DESC
+    config_param :parse_json, :bool,   :default => true,
+                 :desc => "Parse json record."
 
     def configure(conf)
       super


### PR DESCRIPTION
With fluentd 0.12.19, config descriptions are shown like this:

```log
$ bundle exec fluentd --show-plugin-config output:flatten -p lib/fluent/plugin/
2016-01-13 15:21:35 +0900 [info]: Show config for output:flatten
2016-01-13 15:21:35 +0900 [info]: 
key: string: <nil> # The key is used to point a key whose value contains JSON-formatted string.

inner_key: string: <"value"> # This plugin sets `value` for this option as a default if it's not set.

parse_json: bool: <true> # Parse json record.
```

I could't find `parse_json` config description in README. So I added `Parse json record.` for that config variable's description. If you want to add more detail descriptions here, please let me know.