### PR TITLE
Use `@type` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Imagin you have a config as below:
 
 ```
 <match test.**>
-  type flatten
+  @type flatten
 
   key  foo
   add_tag_prefix    flattened.


### PR DESCRIPTION
Because docs.fluentd.org uses it.