### PR TITLE
Add missing require

### DIFF
--- a/lib/fluent/plugin/out_flatten.rb
+++ b/lib/fluent/plugin/out_flatten.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'fluent/plugin/output'
 
 module Fluent::Plugin
   class FlattenOutput < Fluent::Plugin::Output


### PR DESCRIPTION
Because Fluentd developers recommends loading libraries explicitly.