### PR TITLE
Remove parameter requirements for HandleTagNameMixin

### DIFF
--- a/lib/fluent/plugin/out_flatten.rb
+++ b/lib/fluent/plugin/out_flatten.rb
@@ -18,19 +18,6 @@ module Fluent::Plugin
     desc "Replaces spaces in the resulting tag with the key passed"
     config_param :replace_space_in_tag, :string, default: nil
 
-    def configure(conf)
-      super
-
-      if (
-          !remove_tag_prefix &&
-          !remove_tag_suffix &&
-          !add_tag_prefix    &&
-          !add_tag_suffix
-      )
-        raise Fluent::ConfigError, "out_flatten: At least one of remove_tag_prefix/remove_tag_suffix/add_tag_prefix/add_tag_suffix is required to be set"
-      end
-    end
-
     def process(tag, es)
       es.each do |time, record|
         flattened = flatten(record)


### PR DESCRIPTION
because fluentd already has label routing feature.
There is no reason why these parameter is required to be set.